### PR TITLE
fix: enforce WAF result page allowances

### DIFF
--- a/awswafv2_connector.py
+++ b/awswafv2_connector.py
@@ -252,9 +252,13 @@ class AwsWafConnector(BaseConnector):
                 return None
 
             page_count += 1
-            page_items = resp_json.get(set_name, [])
-            if remaining is not None:
-                page_items = page_items[:remaining]
+            page_items = resp_json.get(set_name)
+            if not isinstance(page_items, list):
+                action_result.set_status(phantom.APP_ERROR, f"{set_name} returned an invalid result page")
+                return None
+            if len(page_items) > page_limit:
+                action_result.set_status(phantom.APP_ERROR, f"{set_name} returned more items than the connector requested")
+                return None
             set_list.extend(page_items)
 
             if remaining is not None:

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Reject malformed or oversized WAF result pages before retaining their items.


### PR DESCRIPTION
## Summary

- validate decoded AWS WAF result pages before retaining any items
- reject pages larger than the connector-requested allowance
- apply the control centrally to both list IP sets and list ACLs

## Validation context

This follows source validation for [PAPP-38077](https://splunk.atlassian.net/browse/PAPP-38077), [PSAAS-32220](https://splunk.atlassian.net/browse/PSAAS-32220), and [VULN-94943](https://splunk.atlassian.net/browse/VULN-94943), under [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228). It follows merged PR #32.

The connector can bound decoded item pages, but boto3/botocore materializes the HTTP response before returning it. A strict raw-byte ceiling before transport deserialization remains a shared AWS transport/platform follow-up; this PR does not claim to solve that layer.

## Quality gate

- source compile passed
- `pre-commit run --all-files` passed

Authored by Codex.