### PR TITLE
fix: redact action-scoped AWS credentials

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.8
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.43.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/NOTICE
+++ b/NOTICE
@@ -440,4 +440,3 @@ was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 
 ***** END LICENSE BLOCK *****
-

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ action_result.message | string | | Ip status: IP(s) added successfully |
 action_result.data.\*.NextLockToken | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'delete ip'
 
@@ -153,7 +152,6 @@ action_result.message | string | | Ip status: IP(s) deleted successfully |
 action_result.data.\*.NextLockToken | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'delete ip set'
 
@@ -190,7 +188,6 @@ action_result.parameter.ip_set_id | string | `awswaf ip set id` | 25b7e872-0645-
 action_result.parameter.ip_set_name | string | `awswaf ip set name` | new_ip_set_1383662 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list acls'
 
@@ -221,7 +218,6 @@ action_result.summary.number_of_acls | numeric | | 4 |
 action_result.message | string | | Number of acls: 4 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list ip sets'
 
@@ -252,7 +248,6 @@ action_result.summary.number_of_ip_sets | numeric | | 56 |
 action_result.message | string | | Number of ip sets: 56 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | password | `aws credentials` | |
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **ip_set_id** | optional | ID of the IP set | string | `awswaf ip set id` |
 **ip_set_name** | optional | Name of the IP set | string | `awswaf ip set name` |
 **ip_address** | required | IP Address (Allows comma-separated) | string | `awswaf ip mask` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -113,7 +113,6 @@ action_result.message | string | | Ip status: IP(s) added successfully |
 action_result.data.\*.NextLockToken | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': '\*REDACTED\*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '\*REDACTED\*', 'SessionToken': '\*REDACTED\*'} |
 
 ## action: 'delete ip'
 
@@ -131,7 +130,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 **ip_set_id** | optional | IP Set ID | string | `awswaf ip set id` |
 **ip_set_name** | optional | IP Set Name | string | `awswaf ip set name` |
 **ip_address** | required | IP Address (Allows comma-separated) | string | `awswaf ip mask` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -153,7 +152,6 @@ action_result.message | string | | Ip status: IP(s) deleted successfully |
 action_result.data.\*.NextLockToken | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': '\*REDACTED\*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '\*REDACTED\*', 'SessionToken': '\*REDACTED\*'} |
 
 ## action: 'delete ip set'
 
@@ -170,7 +168,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **ip_set_id** | optional | IP Set ID | string | `awswaf ip set id` |
 **ip_set_name** | optional | IP Set Name | string | `awswaf ip set name` |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -188,7 +186,6 @@ action_result.message | string | | Delete status: IP Set deleted successfully |
 action_result.summary.delete_status | string | | IP Set deleted successfully |
 action_result.parameter.ip_set_id | string | `awswaf ip set id` | 25b7e872-0645-4229-91d5-28e2369262aa |
 action_result.parameter.ip_set_name | string | `awswaf ip set name` | new_ip_set_1383662 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': '\*REDACTED\*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '\*REDACTED\*', 'SessionToken': '\*REDACTED\*'} |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
 
@@ -204,7 +201,7 @@ Read only: **True**
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **limit** | optional | Maximum number of results (default: 100) | numeric | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -221,7 +218,6 @@ action_result.summary.number_of_acls | numeric | | 4 |
 action_result.message | string | | Number of acls: 4 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': '\*REDACTED\*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '\*REDACTED\*', 'SessionToken': '\*REDACTED\*'} |
 
 ## action: 'list ip sets'
 
@@ -235,7 +231,7 @@ Read only: **True**
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **limit** | optional | Maximum number of results (default: 100) | numeric | |
-**credentials** | optional | Assumed role credentials | string | `aws credentials` |
+**credentials** | optional | Assumed role credentials | password | `aws credentials` |
 
 #### Action Output
 
@@ -252,7 +248,6 @@ action_result.summary.number_of_ip_sets | numeric | | 56 |
 action_result.message | string | | Number of ip sets: 56 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
-action_result.parameter.credentials | string | `aws credentials` | {'AccessKeyId': '\*REDACTED\*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '\*REDACTED\*', 'SessionToken': '\*REDACTED\*'} |
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ action_result.message | string | | Ip status: IP(s) added successfully |
 action_result.data.\*.NextLockToken | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'delete ip'
 
@@ -152,6 +153,7 @@ action_result.message | string | | Ip status: IP(s) deleted successfully |
 action_result.data.\*.NextLockToken | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'delete ip set'
 
@@ -188,6 +190,7 @@ action_result.parameter.ip_set_id | string | `awswaf ip set id` | 25b7e872-0645-
 action_result.parameter.ip_set_name | string | `awswaf ip set name` | new_ip_set_1383662 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list acls'
 
@@ -218,6 +221,7 @@ action_result.summary.number_of_acls | numeric | | 4 |
 action_result.message | string | | Number of acls: 4 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ## action: 'list ip sets'
 
@@ -248,6 +252,7 @@ action_result.summary.number_of_ip_sets | numeric | | 56 |
 action_result.message | string | | Number of ip sets: 56 |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.credentials | password | `aws credentials` | |
 
 ______________________________________________________________________
 

--- a/awswafv2.json
+++ b/awswafv2.json
@@ -132,7 +132,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -281,16 +281,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': '*REDACTED*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '*REDACTED*', 'SessionToken': '*REDACTED*'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -337,7 +327,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -474,16 +464,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': '*REDACTED*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '*REDACTED*', 'SessionToken': '*REDACTED*'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -519,7 +499,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -623,16 +603,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': '*REDACTED*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '*REDACTED*', 'SessionToken': '*REDACTED*'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
-                },
-                {
                     "data_path": "summary.total_objects",
                     "data_type": "numeric",
                     "example_values": [
@@ -667,7 +637,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -758,16 +728,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': '*REDACTED*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '*REDACTED*', 'SessionToken': '*REDACTED*'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -790,7 +750,7 @@
                 },
                 "credentials": {
                     "description": "Assumed role credentials",
-                    "data_type": "string",
+                    "data_type": "password",
                     "primary": true,
                     "contains": [
                         "aws credentials"
@@ -885,16 +845,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "string",
-                    "example_values": [
-                        "{'AccessKeyId': '*REDACTED*', 'Expiration': '2021-06-07 22:28:04', 'SecretAccessKey': '*REDACTED*', 'SessionToken': '*REDACTED*'}"
-                    ],
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],

--- a/awswafv2.json
+++ b/awswafv2.json
@@ -281,13 +281,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -471,13 +464,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -629,13 +615,6 @@
                     "example_values": [
                         1
                     ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
-                    ]
                 }
             ],
             "render": {
@@ -748,13 +727,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],
@@ -873,13 +845,6 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.credentials",
-                    "data_type": "password",
-                    "contains": [
-                        "aws credentials"
                     ]
                 }
             ],

--- a/awswafv2.json
+++ b/awswafv2.json
@@ -281,6 +281,13 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -464,6 +471,13 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -615,6 +629,13 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
+                    ]
                 }
             ],
             "render": {
@@ -727,6 +748,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],
@@ -845,6 +873,13 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.credentials",
+                    "data_type": "password",
+                    "contains": [
+                        "aws credentials"
                     ]
                 }
             ],

--- a/awswafv2_connector.py
+++ b/awswafv2_connector.py
@@ -51,6 +51,10 @@ class AwsWafConnector(BaseConnector):
         self._session_token = None
         self._proxy = None
 
+    @staticmethod
+    def _sanitize_action_parameters(param):
+        return {key: value for key, value in param.items() if key != "credentials"}
+
     def _sanitize_data(self, cur_obj):
         try:
             json.dumps(cur_obj)
@@ -290,7 +294,7 @@ class AwsWafConnector(BaseConnector):
 
     def _handle_test_connectivity(self, param):
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         self.save_progress(AWSWAF_INFO_CHECK_CREDENTIALS)
 
@@ -316,7 +320,7 @@ class AwsWafConnector(BaseConnector):
         self.save_progress(AWSWAF_INFO_ACTION.format(self.get_action_identifier()))
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         ip_set_id = param.get("ip_set_id")
         ip_set_name = param.get("ip_set_name")
@@ -361,7 +365,7 @@ class AwsWafConnector(BaseConnector):
         self.save_progress(AWSWAF_INFO_ACTION.format(self.get_action_identifier()))
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         ip_set_id = param.get("ip_set_id")
         ip_set_name = param.get("ip_set_name")
@@ -397,7 +401,7 @@ class AwsWafConnector(BaseConnector):
         self.save_progress(AWSWAF_INFO_ACTION.format(self.get_action_identifier()))
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         ip_set_id = param.get("ip_set_id")
         ip_set_name = param.get("ip_set_name")
@@ -440,7 +444,7 @@ class AwsWafConnector(BaseConnector):
         self.save_progress(AWSWAF_INFO_ACTION.format(self.get_action_identifier()))
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         limit = param.get("limit")
         if limit == 0 or (limit and (not str(limit).isdigit() or limit <= 0)):
@@ -464,7 +468,7 @@ class AwsWafConnector(BaseConnector):
         self.save_progress(AWSWAF_INFO_ACTION.format(self.get_action_identifier()))
 
         # Add an action result object to self (BaseConnector) to represent the action for this param
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._sanitize_action_parameters(param)))
 
         limit = param.get("limit")
         if limit == 0 or (limit and (not str(limit).isdigit() or limit <= 0)):

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Prevent action-scoped AWS credentials from being retained in action results.


### PR DESCRIPTION
Written by Codex.

## Summary

- Mark temporary AWS credentials as password-typed action input.
- Exclude action-scoped credentials before parameters are retained in ActionResult.
- Remove credential parameter paths from action output metadata.
- Refresh shared quality hooks and their generated maintenance artifacts.

## Tracking

- [PAPP-37946](https://splunk.atlassian.net/browse/PAPP-37946)
- [PSAAS-32390](https://splunk.atlassian.net/browse/PSAAS-32390)
- [PSAAS-32390](https://splunk.atlassian.net/browse/PSAAS-32390)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Quality gate

- Full pre-commit suite passes locally and the hosted pre-commit check passes at the corrected head.
- Source compilation passes locally.
- Hosted compile rerun passed on 2026-08-07; no connector-code compile failure remains.

- Security scans are non-blocking under the connector quality policy; integration failures are ignored unless they implicate the changed code.

## Release impact

Asset configuration and credential use are unchanged. The action history no longer retains temporary credential material.

Merge strategy: merge commit only; do not squash.
