### PR TITLE
fix: restore valid AWS WAF IP updates

### DIFF
--- a/awswafv2_connector.py
+++ b/awswafv2_connector.py
@@ -279,16 +279,15 @@ class AwsWafConnector(BaseConnector):
     def validate_params(self, action_result, ip_set_id, ip_set_name, ip_address_list):
         ip_type = ""
         if not ip_set_id and not ip_set_name:
-            return action_result.set_status(phantom.APP_ERROR, AWSWAF_INSUFFICIENT_PARAM)
+            action_result.set_status(phantom.APP_ERROR, AWSWAF_INSUFFICIENT_PARAM)
+            return None
 
         for ip_address in ip_address_list:
             ip_type = self._validate_ip(ip_address)
 
             if ip_type is None:
-                return action_result.set_status(phantom.APP_ERROR, AWSWAF_INVALID_IP)
-
-            if not ip_type:
-                return action_result.set_status(phantom.APP_ERROR, AWSWAF_INVALID_IP)
+                action_result.set_status(phantom.APP_ERROR, AWSWAF_INVALID_IP)
+                return None
 
         return ip_type
 
@@ -327,7 +326,7 @@ class AwsWafConnector(BaseConnector):
         ip_address = param.get("ip_address")
         ip_address_list = [x.strip() for x in ip_address.split(",") if x.strip()]
         ip_type = self.validate_params(action_result, ip_set_id, ip_set_name, ip_address_list)
-        if action_result.get_status() == phantom.APP_ERROR:
+        if ip_type is None:
             return action_result.get_status()
 
         ip_set = self.paginator(AWSWAF_DEFAULT_LIMIT, action_result, param)
@@ -372,8 +371,7 @@ class AwsWafConnector(BaseConnector):
         ip_address = param.get("ip_address")
 
         ip_address_list = [x.strip() for x in ip_address.split(",") if x.strip()]
-        self.validate_params(action_result, ip_set_id, ip_set_name, ip_address_list)
-        if action_result.get_status() == phantom.APP_ERROR:
+        if self.validate_params(action_result, ip_set_id, ip_set_name, ip_address_list) is None:
             return action_result.get_status()
 
         ip_set = self.paginator(AWSWAF_DEFAULT_LIMIT, action_result, param)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Fix `add ip` and `delete ip` actions exiting before valid AWS WAF updates.


### PR DESCRIPTION
## Summary

Fix the AWS WAF V2 `add ip` and `delete ip` regression reported in [SOARHELP-7070](https://splunk.atlassian.net/browse/SOARHELP-7070).

Both actions work in app 2.1.9 but exit immediately with an empty failure message in 2.1.11 and 2.1.12.

## Root cause

The 2.1.11 status-hardening change checked `action_result.get_status() == APP_ERROR` immediately after parameter validation. A newly-created SOAR `ActionResult` remains in its initial error state until an operation explicitly sets a status, including when validation succeeds. Valid requests therefore returned before pagination or any AWS API call.

## Changes

- Make `validate_params` return `None` for invalid parameters after setting the specific error status.
- Have `add ip` and `delete ip` branch on that explicit validation result instead of the initial `ActionResult` status.
- Preserve the 2.1.11 behavior that retains failed AWS update statuses and summaries.
- Add an unreleased note.

## Impact

Valid `add ip` and `delete ip` actions once again reach the AWS WAF update path. Invalid IP addresses or missing IP-set identifiers still stop before AWS calls with their existing error messages.

## Validation

- Isolated regression harness modeling SOAR's initial `ActionResult` error state:
  - valid `add ip` reaches `_ip_update`
  - valid `delete ip` reaches `_ip_update`
  - invalid parameters stop before pagination
- Python compilation passed.
- Connector pre-commit checks passed for formatting, Ruff, SOAR app linting, secret detection, generated docs, release notes, and static tests.
- Semgrep could not initialize the local macOS CA trust store.
- Dependency packaging could not run because Docker is unavailable in the local environment.
